### PR TITLE
Buff sniper AP rounds

### DIFF
--- a/game_scripts/weapons/weapon_paladin.txt
+++ b/game_scripts/weapons/weapon_paladin.txt
@@ -35,7 +35,7 @@
 			"weapon_overrides"
 			{
 				"damage_multiplier"	"0.75"
-				"exo_multiplier"	"4"
+				"exo_multiplier"	"4.3"
 			}
 		}
 		"clip_compression_1"

--- a/game_scripts/weapons/weapon_psg.txt
+++ b/game_scripts/weapons/weapon_psg.txt
@@ -35,7 +35,7 @@
 			"weapon_overrides"
 			{
 				"damage_multiplier"	"0.75"
-				"exo_multiplier"	"4"
+				"exo_multiplier"	"4.3"
 			}
 		}
 		"clip_compression_1"


### PR DESCRIPTION
Increase exo damage with ap rounds from 400% to 430%. Allows for two body shots to kill by good aim or infantry boost.